### PR TITLE
[http-auth] Update to Converse 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,8 @@
     <script src="packages/offline-reply/webpush-browserify-bundle.js"></script>
     <script src="packages/offline-reply/offline-reply.js"></script>
 
+    <script src="packages/http-auth/http-auth.js"></script>
+
 </head>
 <body class="reset">
     <div class="converse-content" style="display:none">
@@ -90,7 +92,7 @@
         websocket_url: 'wss://conversejs.org/xmpp-websocket',
         view_mode: 'fullscreen',
         loglevel: 'debug',
-        whitelisted_plugins: ["download-dialog", "stickers", "toolbar-utilities", "search", "directory", "muc-directory", "diagrams", "vmsg", "screencast", "jitsimeet", "location", "offline-reply"]
+        whitelisted_plugins: ["download-dialog", "stickers", "toolbar-utilities", "search", "directory", "muc-directory", "diagrams", "vmsg", "screencast", "jitsimeet", "location", "offline-reply", "http-auth"]
     };
 
     converse.initialize( config )

--- a/packages/http-auth/http-auth.js
+++ b/packages/http-auth/http-auth.js
@@ -1,5 +1,4 @@
 /**
-
  * @module converse-http-auth
  * @description
  * Converse.js plugin which add support verification of an HTTP request via XMPP.
@@ -7,145 +6,149 @@
  * Author: Arnaud Joset
  */
 
-(function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define(["converse"], factory);
-    } else {
-        factory(converse);
-    }
-}(this, function (converse) {
-    'use strict';
-    // The following line registers your plugin.
-    converse.plugins.add("http-auth", {
-        dependencies: [],
-        // https://xmpp.org/extensions/xep-0070.html
-        initialize: function () {
-            const _converse = this._converse;
-            const nsHttpAuth = "http://jabber.org/protocol/http-auth";
-            const options = {
-                ns: nsHttpAuth,
-            };
 
-            _converse.api.settings.update({
+const plugin = {
+    dependencies: [],
+    initialize() {
+
+        const { _converse } = this;
+        const { api, log } = _converse;
+
+        api.settings.extend({
+            'initialize_message': 'Initializing http-auth!',
             'hidden': [],
-            });
+        });
+        _converse.api.listen.on('connected', startListeners);
 
-            _converse.api.listen.on('connected', startListeners);
-            function startListeners() {
-                _converse.api.listen.stanza('message', options, stanzaHandler);
-                _converse.api.listen.stanza('iq', options, stanzaHandler);
-                return true;
-            }
-            _converse.api.listen.on('chatBoxInsertedIntoDOM', model => {
+        function startListeners() {
+            _converse.api.listen.stanza('message', { ns: "http://jabber.org/protocol/http-auth" }, stanzaHandler);
+            _converse.api.listen.stanza('iq', { ns: "http://jabber.org/protocol/http-auth" }, stanzaHandler);
+
+        }
+        api.listen.on('chatBoxInsertedIntoDOM', model => {
+            if (_converse.settings.hidden.includes(model.model.id)) {
                 // Prevent the forbidden chatbox to be displayed
-                if (_converse.hidden.includes(model.model.id)) {
-                    console.info("Hiding ", model.model.id, " chatBox");
-                    model._removeElement()
-                }
-            });
-            const httpAuthDialog = _converse.BootstrapModal.extend({
-
-                events: {
-                  'click .btn-acceptAuth': 'acceptAuth',
-                  'click .btn-refuseAuth': 'refuseAuth',
-                },
-
-                initialize(httpAuthData) {
-                    const self = this;
-                    self.httpAuthData = httpAuthData;
-                    _converse.BootstrapModal.prototype.initialize.apply(this, arguments);
-                },
-                toHTML() {
-                    const self = this;
-                    const __ = _converse.__;
-                    const title = __('Confirmation of Authentication');
-                    const question = __('The following platform needs to validate your identity, do you agree ?');
-                    const vc = __('Validation Code : ');
-                    const accept = __('Accept');
-                    const refuse = __('Refuse');
-                    let dialog = '<div class="modal" id="httpAuth"> <div class="modal-dialog"> <div class="modal-content">' +
-                                '<div class="modal-header">' +
-                                '<h2 class="modal-title">{title}</h2>' +
-                                '<button type="button" class="close" data-dismiss="modal">&times;</button></div>' +
-                                '<div class="modal-body" style="text-align:center">{question}</br>' +
-                                '<strong>{from}</strong>' +
-                                '</br>{vc}</br>' +
-                                '<strong>{id}</strong></div>' +
-                                '<div class="modal-footer" style="text-align:center">' +
-                                '<button type="button" class="btn btn-success btn-acceptAuth" data-dismiss="modal">{accept}</button>' +
-                                '<button type="button" class="btn btn-danger btn-refuseAuth" data-dismiss="modal">{refuse}</button>' +
-                                '</div></div></div>';
-                    dialog = dialog.replace("{from}", self.httpAuthData.from).replace("{id}", self.httpAuthData.id);
-                    dialog = dialog.replace("{title}", title).replace("{question}", question).replace("{vc}", vc);
-                    dialog = dialog.replace("{accept}", accept).replace("{refuse}", refuse);
-                    return dialog;
-                },
-
-                buildResponse(responseType) {
-                    const self = this;
-                    const response = self.httpAuthData['response'];
-                    let iqType = 'get';
-                    response.c('confirm', {'xmlns': 'http://jabber.org/protocol/http-auth',
-                            'id': self.httpAuthData['id'], 'method': self.httpAuthData['method'],
-                            'url': self.httpAuthData['url']}).up();
-                    if (responseType === 'refuse') {
-                        response.c('error', {'code': '401', 'type': 'auth'});
-                        response.c('not-authorized', {'xmlns': 'urn:ietf:params:xml:xmpp-stanzas'});
-                        iqType = 'error';
-                      }
-                    if (self.httpAuthData['stanzaType'] === 'iq') {
-                        response = response.attrs({type: iqType});
-                    }
-                  _converse.api.send(response);
-                },
-                acceptAuth() {
-                    this.buildResponse('accept');
-                },
-                refuseAuth() {
-                    this.buildResponse('refuse');
-                },
-            });
-
-            function stanzaHandler(stanza) {
-                if (stanza.localName === 'message' || stanza.localName === 'iq') {
-                    let confirm = stanza.getElementsByTagName('confirm');
-                    if (confirm.length > 0) {
-                        confirm = confirm[0];
-                        const httpAuthData = {
-                            xmlns: confirm.getAttribute('xmlns'),
-                            method: confirm.getAttribute('method'),
-                            id: confirm.getAttribute('id'),
-                            url: confirm.getAttribute('url'),
-                            from: stanza.getAttribute('from'),
-                            to: stanza.getAttribute('to'),
-                            confirm: confirm,
-                            message: stanza,
-                            stanzaType: stanza.localName
-                        };
-                        let httpAuthMessage;
-                        if (stanza.localName === 'message') {
-                            httpAuthMessage = converse.env.$msg({
-                                from: _converse.jid,
-                                to: stanza.getAttribute('from'),
-                            });
-                            const thread = stanza.getElementsByTagName('thread')[0].textContent;
-                            httpAuthMessage.c('thread').t(thread).up();
-                            httpAuthData['response'] = httpAuthMessage;
-                        } else {
-                            httpAuthMessage = converse.env.$iq({
-                                from: _converse.jid,
-                                to: stanza.getAttribute('from'),
-                                id: stanza.getAttribute('id'),
-                                type: 'error',
-                            });
-                            httpAuthData.response = httpAuthMessage;
-                        }
-                        new httpAuthDialog(httpAuthData).show();
-                    }
-                }
-                return true;
+                console.info("Hiding ", model.model.id, " chatBox");
+                model._removeElement()
             }
-            console.info("http-auth plugin is ready");
-        },
-    });
-}));
+        });
+
+        BootstrapModal = converse.env.BootstrapModal;
+        __ = _converse.__;
+        html = converse.env.html;
+        Model = converse.env.Model;
+        const httpAuthDialog = BootstrapModal.extend({
+            events: {
+                'click .btn-acceptAuth': 'acceptAuth',
+                'click .btn-refuseAuth': 'refuseAuth',
+            },
+
+            initialize() {
+                BootstrapModal.prototype.initialize.apply(this, arguments);
+                this.listenTo(this.model, 'change', this.render);
+            },
+
+            toHTML() {
+                const httpAuthData = this.model.attributes.data;
+                const title = __('Confirmation of Authentication');
+                const question = __('The following platform needs to validate your identity, do you agree ?');
+                const fromJid = httpAuthData.from;
+                const vc = __('Validation Code : ');
+                const id = httpAuthData.id;
+                const accept = __('Accept');
+                const refuse = __('Refuse');
+                return html`<div id="httpAuth"> <div class="modal-dialog"> <div class="modal-content">
+                            <div class="modal-header">
+                            <h2 class="modal-title">${title}</h2>
+                            <button type="button" class="close" data-dismiss="modal">&times;</button></div>
+                            <div class="modal-body" style="text-align:center">${question}</br>
+                            <strong>${fromJid}</strong>
+                            </br>${vc}</br>
+                            <strong>${id}</strong></div>
+                            <div class="modal-footer" style="text-align:center">
+                            <button type="button" class="btn btn-success btn-acceptAuth" data-dismiss="modal">${accept}</button>
+                            <button type="button" class="btn btn-danger btn-refuseAuth" data-dismiss="modal">${refuse}</button>
+                            </div></div></div>`;
+            },
+
+            buildResponse(responseType) {
+                const httpAuthData = this.model.attributes.data;
+                const response = httpAuthData['response'];
+                let iqType = 'get';
+                response.c('confirm', {
+                    'xmlns': 'http://jabber.org/protocol/http-auth',
+                    'id': httpAuthData['id'], 'method': httpAuthData['method'],
+                    'url': httpAuthData['url']
+                }).up();
+                if (responseType === 'refuse') {
+                    response.c('error', { 'code': '401', 'type': 'auth' });
+                    response.c('not-authorized', { 'xmlns': 'urn:ietf:params:xml:xmpp-stanzas' });
+                    iqType = 'error';
+                }
+                if (httpAuthData['stanzaType'] === 'iq') {
+                    response = response.attrs({ type: iqType });
+                }
+                _converse.api.send(response);
+            },
+            acceptAuth() {
+                this.buildResponse('accept');
+            },
+            refuseAuth() {
+                this.buildResponse('refuse');
+            },
+        });
+
+        function stanzaHandler(stanza) {
+            if (stanza.localName === 'message' || stanza.localName === 'iq') {
+                let confirm = stanza.getElementsByTagName('confirm');
+                if (confirm.length > 0) {
+                    confirm = confirm[0];
+                    const httpAuthData = {
+                        xmlns: confirm.getAttribute('xmlns'),
+                        method: confirm.getAttribute('method'),
+                        id: confirm.getAttribute('id'),
+                        url: confirm.getAttribute('url'),
+                        from: stanza.getAttribute('from'),
+                        to: stanza.getAttribute('to'),
+                        confirm: confirm,
+                        message: stanza,
+                        stanzaType: stanza.localName
+                    };
+                    let httpAuthMessage;
+                    if (stanza.localName === 'message') {
+                        httpAuthMessage = converse.env.$msg({
+                            from: _converse.jid,
+                            to: stanza.getAttribute('from'),
+                        });
+                        const thread = stanza.getElementsByTagName('thread')[0].textContent;
+                        httpAuthMessage.c('thread').t(thread).up();
+                        httpAuthData['response'] = httpAuthMessage;
+                    } else {
+                        httpAuthMessage = converse.env.$iq({
+                            from: _converse.jid,
+                            to: stanza.getAttribute('from'),
+                            id: stanza.getAttribute('id'),
+                            type: 'error',
+                        });
+                        httpAuthData.response = httpAuthMessage;
+                    }
+
+                    const confirmDialog = new httpAuthDialog({ 'model': new Model({ view: _converse.rosterview, data: httpAuthData }) });
+                    confirmDialog.show();
+                }
+            }
+            return true;
+        };
+        console.info("http-auth plugin is ready");
+
+    },
+}
+
+if (typeof converse === "undefined") {
+    window.addEventListener(
+        'converse-loaded',
+        () => converse.plugins.add("http-auth", plugin)
+    );
+} else {
+    converse.plugins.add("http-auth", plugin);
+}


### PR DESCRIPTION
Before this commit, the http-auth plugin was not properly working.
If you want to hide the authentication request of your provider, you can set the following option in your converse settings:

```
hidden: ['auth.example.com']
```

It will work with any jid.
You can test the implementation with the following test website: https://demo.agayon.be/