### PR TITLE
Suggestion of some modifications for the jitsimeet plugin.

### DIFF
--- a/packages/jitsimeet/jitsimeet.js
+++ b/packages/jitsimeet/jitsimeet.js
@@ -5,7 +5,7 @@
         factory(converse);
     }
 }(this, function (converse) {
-    var Strophe, $iq, $msg, $pres, $build, b64_sha1, _ , dayjs, _converse, html, _, __, Model, BootstrapModal, jitsimeet_confirm, jitsimeet_invitation;
+    var Strophe, $iq, $msg, $pres, $build, b64_sha1, _ , dayjs, _converse, html, _, __, Model, BootstrapModal, jitsimeet_confirm, jitsimeet_invitation, jitsimeet_tab_invitation;
     var MeetDialog = null, meetDialog = null;
 
     converse.plugins.add("jitsimeet", {
@@ -32,8 +32,9 @@
                 jitsimeet_url: 'https://meet.jit.si',
             });
 
-            jitsimeet_confirm  = __('Meeting?'),
+            jitsimeet_confirm  = __('Meeting?');
             jitsimeet_invitation = __('Please join meeting in room at');
+            jitsimeet_tab_invitation = __('Or open in new tab at');
 
             _converse.on('message', function (data)
             {
@@ -67,12 +68,11 @@
                         {
                             event.preventDefault();
 
-                            var box_jid = Strophe.getBareJidFromJid(chatbox.get("from") || chatbox.get("jid"));
+                            var box_jid = Strophe.getBareJidFromJid(chatbox.get("contact_jid") || chatbox.get("jid") || chatbox.get("from"));
                             var view = _converse.chatboxviews.get(box_jid);
 
                             if (view)
                             {
-                                openChatbox(view);
                                 doLocalVideo(view, room, url + "/" + room, label);
                             }
                         }
@@ -148,13 +148,17 @@
                         console.debug("afterMessageBodyTransformed", body, text);
 
                         const url = body.substring(pos);
-                        const link_jid = Strophe.getBareJidFromJid(model.get("from") || model.get("jid"));
+                        const link_jid = Strophe.getBareJidFromJid(model.get("contact_jid") || model.get("jid") || model.get("from"));
                         const link_room = url.substring(url.lastIndexOf("/") + 1);
                         const link_label = jitsimeet_invitation;
+                        const tab_label = jitsimeet_tab_invitation;
                         const link_id = link_room + "-" + Math.random().toString(36).substr(2,9);
 
                         text.references = [];
-                        text.addTemplateResult(0, body.length, html`<a @click=${clickVideo} data-room="${link_room}" data-url="${url}" data-jid="${link_jid}" id="${link_id}" href="#">${link_label} ${link_room}</a>`);
+                        text.addTemplateResult(0, body.length, html`<a 
+                            @click=${clickVideo} data-room="${link_room}" data-url="${url}" data-jid="${link_jid}" id="${link_id}"
+                            href="#">${link_label} ${link_room}</a><br/><a target="_blank" rel="noopener"
+                            href="${url}">${tab_label} ${url}</a>`);
                     }
                 }
             });
@@ -189,7 +193,7 @@
 
     var doVideo = function doVideo(view)
     {
-        const room = Strophe.getNodeFromJid(view.model.attributes.jid).toLowerCase() + "-" + Math.random().toString(36).substr(2,9);
+        const room = Strophe.getNodeFromJid(view.model.attributes.jid).toLowerCase().replace(/[\\]/g, '') + "-" + Math.random().toString(36).substr(2,9);
         const url = _converse.api.settings.get("jitsimeet_url") + '/' + room;
 
         console.debug("doVideo", room, url, view);
@@ -197,7 +201,6 @@
         const label = jitsimeet_invitation;
         const attrs = view.model.getOutgoingMessageAttributes(url);
         const message = view.model.messages.create(attrs);
-        message.set('oob_url', url);
 
         _converse.api.send(view.model.createMessageStanza(message));
         doLocalVideo(view, room, url, label);
@@ -224,40 +227,44 @@
 
             if (div)
             {
-                div.innerHTML = '<iframe src="' + url + '" id="jitsimeet" allow="microphone; camera;" frameborder="0" seamless="seamless" allowfullscreen="true" scrolling="no" style="z-index: 2147483647;width:100%;height:-webkit-fill-available;height:-moz-available;"></iframe>';
+                const divChildElements = [].slice.call(div.children, 0).map(function(bloc) {
+                  const data = {
+                    el : bloc,
+                    previousDisplay : bloc.style.display
+                  }
+                  bloc.style.display = 'none';
+                  return data;
+                });
+                let jitsiFrame = document.createElement('iframe');
 
-                var jitsiDiv = div.querySelector('#jitsimeet');
                 var firstTime = true;
 
-                jitsiDiv.addEventListener("load", function ()
+                jitsiFrame.addEventListener("load", function ()
                 {
                     console.debug("doVideo - load", this);
 
                     if (!firstTime) // meeting closed and root url is loaded
                     {
-                        view.close();
-                        openChatbox(view);
+                        jitsiFrame.remove();
+                        divChildElements.forEach(function(bloc) {
+                          bloc.el.style.display = bloc.previousDisplay;
+                        })
                     }
 
                     if (firstTime) firstTime = false;   // ignore when jitsi-meet room url is loaded
 
                 });
+
+                jitsiFrame.setAttribute("src", url);
+                jitsiFrame.setAttribute("id", "jitsimeet");
+                jitsiFrame.setAttribute("allow", "microphone; camera;");
+                jitsiFrame.setAttribute("frameborder", "0");
+                jitsiFrame.setAttribute("seamless", "seamless");
+                jitsiFrame.setAttribute("allowfullscreen", "true");
+                jitsiFrame.setAttribute("scrolling", "no");
+                jitsiFrame.setAttribute("style", "z-index: 2147483647;width:100%;height:100%;");
+                div.appendChild(jitsiFrame);
             }
-        }
-    }
-
-    var openChatbox = function openChatbox(view)
-    {
-        let jid = view.model.get("jid");
-        let type = view.model.get("type");
-
-        if (jid)
-        {
-            view.close();
-
-            if (type == "chatbox") _converse.api.chats.open(jid, {'bring_to_foreground': true}, true);
-            else
-            if (type == "chatroom") _converse.api.rooms.open(jid, {'bring_to_foreground': true}, true);
         }
     }
 }));


### PR DESCRIPTION
Hiding room HTML content and appending the Jitsi iFrame in order to avoid to close and open again the room to recover messages.

Not using 'oob_url' in order to avoid having a message and link which are not corresponding to the action of opening the meeting in a new tab.

Fixing the link which permits to open meeting into the room which was not always working from the room of the user that initialized the meeting.