### PR TITLE
Suggestion of a second way to handle the close of the jitsi meet iframe displayed into a room

### DIFF
--- a/packages/jitsimeet/jitsimeet.js
+++ b/packages/jitsimeet/jitsimeet.js
@@ -239,7 +239,7 @@
 
                 var firstTime = true;
 
-                jitsiFrame.addEventListener("load", function ()
+                let closeJitsi = function ()
                 {
                     console.debug("doVideo - load", this);
 
@@ -253,8 +253,8 @@
 
                     if (firstTime) firstTime = false;   // ignore when jitsi-meet room url is loaded
 
-                });
-
+                };
+                jitsiFrame.addEventListener("load", closeJitsi);
                 jitsiFrame.setAttribute("src", url);
                 jitsiFrame.setAttribute("id", "jitsimeet");
                 jitsiFrame.setAttribute("allow", "microphone; camera;");
@@ -264,6 +264,15 @@
                 jitsiFrame.setAttribute("scrolling", "no");
                 jitsiFrame.setAttribute("style", "z-index: 2147483647;width:100%;height:100%;");
                 div.appendChild(jitsiFrame);
+                jitsiFrame.contentWindow.addEventListener("message", function (event) {
+                  if (_converse.api.settings.get("jitsimeet_url").indexOf(event.origin) === 0 && typeof event.data === 'string') {
+                    let data = JSON.parse(event.data);
+                    let jitsiEvent = data['jitsimeet_event'];
+                    if ('close' === jitsiEvent) {
+                      closeJitsi();
+                    }
+                  }
+                }, false);
             }
         }
     }


### PR DESCRIPTION
Adding a second way to handle the close of the jitsi meet iframe displayed into a room by using the javascript API Window.postMessage.

This new way permits to handle a clean close from a jitsi meet iframe initialized from another provider (when jitsimeet_url setting is different from 'https://meet.jit.si'). Indeed, the other provider could itself create the meet iframe by using the jitsi IFrame API in order to get more control about the meet initialization and management. In that case, it can use the Window.postMessage API to send a message to the jitsimeet plugin when closing a meet. Jitsimeet plugin close properly the meet iframe when it receives the message with data : `JSON.stringify({'jitsimeet_event' : 'close'})`.